### PR TITLE
fix: align destructive gates across tool planes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,14 @@ GRAVITY_FORMS_BASE_URL=https://yoursite.com
 # ============================================================
 # SECURITY
 # ============================================================
-# Set to 'true' to enable DELETE operations (forms, entries, feeds)
+# Set to 'true' to enable DELETE operations (forms, fields, entries, feeds)
 # WARNING: This allows permanent deletion of data
 GRAVITY_FORMS_ALLOW_DELETE=false
+
+# Optional override for destructive GravityKit product abilities. When unset,
+# this inherits GRAVITY_FORMS_ALLOW_DELETE so one full-access deployment can
+# use a single switch across both capability planes.
+# GRAVITYKIT_ALLOW_DELETE=false
 
 # SSL Certificate Validation (for local development only)
 # Set to 'true' to allow self-signed SSL certificates (Laravel Valet, MAMP, Local WP, etc.)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Two planes: **Gravity Forms** (`gf_*`) — 26 static tools, listed whenever Grav
 ### Field Operations (4 tools)
 - `gf_add_field`        - Add fields with intelligent positioning
 - `gf_update_field`     - Update fields with dependency checking
-- `gf_delete_field`     - Delete fields with cascade options
+- `gf_delete_field`     - Delete fields with cascade options (requires ALLOW_DELETE=true)
 - `gf_list_field_types` - List the 46 supported field types (summary by default; `detail=true` for full metadata, `include_variants=true` for variants)
 
 ### Submissions (2 tools)
@@ -167,7 +167,8 @@ Set these as environment variables — in your MCP client's `env` block (the `np
 ### Optional Settings
 - `GRAVITY_FORMS_AUTH_METHOD`          - Override auto-selection: `basic` or `oauth`/`oauth1` (normally leave unset)
 - `GRAVITY_FORMS_ALLOW_HTTP_BASIC_AUTH=false` - Allow Basic auth to a REMOTE plain-HTTP host (credentials visible to the network)
-- `GRAVITY_FORMS_ALLOW_DELETE=false`   - Enable delete operations
+- `GRAVITY_FORMS_ALLOW_DELETE=false`   - Enable Gravity Forms delete operations (forms, fields, entries, feeds)
+- `GRAVITYKIT_ALLOW_DELETE=false`      - Override destructive GravityKit ability access; inherits `GRAVITY_FORMS_ALLOW_DELETE` when unset
 - `GRAVITY_FORMS_TIMEOUT=30000`        - Request timeout (ms)
 - `GRAVITY_FORMS_MAX_RETRIES=3`        - Max retry attempts for failed requests
 - `GRAVITY_FORMS_DEBUG=false`          - Enable debug logging

--- a/src/abilities/loader.js
+++ b/src/abilities/loader.js
@@ -72,18 +72,26 @@ export function methodForAbility(annotations = {}) {
  * Translate WordPress Abilities annotations to MCP ToolAnnotations.
  * Keeping these hints on dynamic tools lets clients distinguish reads from
  * mutations and destructive calls instead of treating every catalog tool as
- * unclassified.
+ * unclassified. Unknown/null WordPress annotations are omitted so MCP's
+ * conservative defaults remain in force.
  *
  * @param {object} annotations Ability meta.annotations.
  * @returns {object} MCP ToolAnnotations.
  */
 export function normalizeMcpAnnotations(annotations = {}) {
-  return {
-    readOnlyHint: annotations?.readonly === true,
-    destructiveHint: annotations?.destructive === true,
-    idempotentHint: annotations?.idempotent === true,
-    openWorldHint: true,
-  };
+  const normalized = {};
+  const mappings = [
+    ['readonly', 'readOnlyHint'],
+    ['destructive', 'destructiveHint'],
+    ['idempotent', 'idempotentHint'],
+  ];
+  for (const [source, target] of mappings) {
+    if (typeof annotations?.[source] === 'boolean') {
+      normalized[target] = annotations[source];
+    }
+  }
+  normalized.openWorldHint = true;
+  return normalized;
 }
 
 /**

--- a/src/abilities/loader.js
+++ b/src/abilities/loader.js
@@ -69,6 +69,36 @@ export function methodForAbility(annotations = {}) {
 }
 
 /**
+ * Translate WordPress Abilities annotations to MCP ToolAnnotations.
+ * Keeping these hints on dynamic tools lets clients distinguish reads from
+ * mutations and destructive calls instead of treating every catalog tool as
+ * unclassified.
+ *
+ * @param {object} annotations Ability meta.annotations.
+ * @returns {object} MCP ToolAnnotations.
+ */
+export function normalizeMcpAnnotations(annotations = {}) {
+  return {
+    readOnlyHint: annotations?.readonly === true,
+    destructiveHint: annotations?.destructive === true,
+    idempotentHint: annotations?.idempotent === true,
+    openWorldHint: true,
+  };
+}
+
+/**
+ * Resolve the local destructive-ability gate. A product-specific setting can
+ * override the Gravity Forms setting; otherwise one full-access credential can
+ * use a single delete switch across both capability planes.
+ */
+export function resolveAbilityDeletePolicy(env = process.env) {
+  if (env.GRAVITYKIT_ALLOW_DELETE !== undefined) {
+    return env.GRAVITYKIT_ALLOW_DELETE === 'true';
+  }
+  return env.GRAVITY_FORMS_ALLOW_DELETE === 'true';
+}
+
+/**
  * Coerce an ability's `input_schema` payload into a JSON Schema object the
  * MCP runtime can validate (`{ type: "object", properties: {...} }`).
  *
@@ -175,15 +205,20 @@ function arrayToProperties(arr) {
  *   built-in (static) tool set — e.g. the released gf_* contract.
  *   Catalog abilities resolving to a reserved name are skipped with a
  *   warning so the dynamic pipeline can never shadow a shipped tool.
+ * @param {boolean} [options.allowDelete] Allow destructive dynamic abilities.
+ *   Defaults to GRAVITYKIT_ALLOW_DELETE, then GRAVITY_FORMS_ALLOW_DELETE.
  * @returns {Promise<{ definitions: object[], handlers: Record<string, Function>, count: number, source: 'foundation-catalog'|'wp-core' }>}
  */
-export async function loadAbilitiesAsTools(wpClient, { reservedNames } = {}) {
+export async function loadAbilitiesAsTools(
+  wpClient,
+  { reservedNames, allowDelete = resolveAbilityDeletePolicy() } = {},
+) {
   try {
     const items = await fetchFoundationCatalogItems(wpClient);
     const entries = catalogItemsToEntries(items);
 
     if (entries.length > 0) {
-      return buildTools(wpClient, entries, 'foundation-catalog', reservedNames);
+      return buildTools(wpClient, entries, 'foundation-catalog', reservedNames, allowDelete);
     }
 
     logger.warn(`Foundation catalog at ${FOUNDATION_CATALOG_ROUTE} returned no usable abilities — falling back to WP core catalog`);
@@ -192,7 +227,7 @@ export async function loadAbilitiesAsTools(wpClient, { reservedNames } = {}) {
   }
 
   const entries = await fetchCoreEntries(wpClient);
-  return buildTools(wpClient, entries, 'wp-core', reservedNames);
+  return buildTools(wpClient, entries, 'wp-core', reservedNames, allowDelete);
 }
 
 /**
@@ -337,9 +372,10 @@ async function fetchCoreEntries(wpClient) {
  * @param {Array}  entries  Normalized tool entries.
  * @param {string} source   Which catalog produced the entries.
  * @param {Set<string>} [reservedNames] Names owned by the built-in tool set.
+ * @param {boolean} allowDelete Whether destructive ability handlers may run.
  * @returns {{ definitions: object[], handlers: Record<string, Function>, count: number, source: string }}
  */
-function buildTools(wpClient, entries, source, reservedNames) {
+function buildTools(wpClient, entries, source, reservedNames, allowDelete) {
   const definitions = [];
   const handlers = {};
   const claimedBy = new Map();
@@ -368,16 +404,26 @@ function buildTools(wpClient, entries, source, reservedNames) {
       name: entry.toolName,
       description: entry.description,
       inputSchema: normalizeInputSchema(entry.rawInputSchema),
+      annotations: normalizeMcpAnnotations(entry.annotations),
     });
 
     // Closure captures the ability name + method so the dispatcher
-    // doesn't need to re-resolve them at call time. Destructive
-    // gating lives server-side: each ability's permission_callback
-    // (e.g. delete_post for view-delete) plus Foundation's
-    // per-ability enable/disable toggles.
+    // doesn't need to re-resolve them at call time. Destructive calls need
+    // both the local opt-in and the server-side permission_callback (e.g.
+    // delete_post for view-delete); Foundation's per-ability enable/disable
+    // toggles remain an additional server-side boundary.
     const abilityName = entry.abilityName;
     const method      = methodForAbility(entry.annotations);
-    handlers[entry.toolName] = async (params) => executeAbility(wpClient, abilityName, method, params || {});
+    const isDestructive = entry.annotations?.destructive === true;
+    handlers[entry.toolName] = async (params) => {
+      if (isDestructive && !allowDelete) {
+        throw new Error(
+          'Destructive GravityKit abilities are disabled. Set GRAVITYKIT_ALLOW_DELETE=true '
+          + '(or GRAVITY_FORMS_ALLOW_DELETE=true as the shared fallback) to enable.',
+        );
+      }
+      return executeAbility(wpClient, abilityName, method, params || {});
+    };
   }
 
   return { definitions, handlers, count: definitions.length, source };

--- a/src/field-operations/field-manager.js
+++ b/src/field-operations/field-manager.js
@@ -161,6 +161,10 @@ export class FieldManager {
    * Delete field with comprehensive dependency analysis
    */
   async deleteField(formId, fieldId, options = {}) {
+    if (!this.api.allowDelete) {
+      throw new Error('Delete operations are disabled. Set GRAVITY_FORMS_ALLOW_DELETE=true to enable.');
+    }
+
     const { cascade = false, force = false } = options;
     
     // Fetch form

--- a/src/field-operations/index.js
+++ b/src/field-operations/index.js
@@ -317,7 +317,7 @@ export const fieldOperationTools = [
   },
   {
     name: 'gf_delete_field',
-    description: 'Delete a field (checks dependencies)',
+    description: 'Delete a field (checks dependencies; requires ALLOW_DELETE=true)',
     annotations: { destructiveHint: true, openWorldHint: true },
     inputSchema: {
       type: 'object',

--- a/test/abilities-loader.test.js
+++ b/test/abilities-loader.test.js
@@ -11,6 +11,8 @@
 import { TestRunner, TestAssert } from './helpers.js';
 import {
   normalizeInputSchema,
+  normalizeMcpAnnotations,
+  resolveAbilityDeletePolicy,
   loadAbilitiesAsTools,
   methodForAbility,
   FOUNDATION_CATALOG_ROUTE,
@@ -140,6 +142,46 @@ suite.test('normalizeInputSchema: never mutates its input', () => {
   const before = JSON.stringify(input);
   normalizeInputSchema(input);
   TestAssert.equal(JSON.stringify(input), before, 'input was mutated');
+});
+
+suite.test('normalizeMcpAnnotations: preserves ability safety metadata for MCP clients', () => {
+  TestAssert.deepEqual(
+    normalizeMcpAnnotations({ readonly: true, destructive: false, idempotent: true }),
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  );
+  TestAssert.deepEqual(
+    normalizeMcpAnnotations({ destructive: true, idempotent: false }),
+    {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  );
+});
+
+suite.test('resolveAbilityDeletePolicy: product override wins and otherwise inherits the GF flag', () => {
+  TestAssert.equal(resolveAbilityDeletePolicy({}), false);
+  TestAssert.equal(resolveAbilityDeletePolicy({ GRAVITY_FORMS_ALLOW_DELETE: 'true' }), true);
+  TestAssert.equal(
+    resolveAbilityDeletePolicy({
+      GRAVITY_FORMS_ALLOW_DELETE: 'true',
+      GRAVITYKIT_ALLOW_DELETE: 'false',
+    }),
+    false,
+  );
+  TestAssert.equal(
+    resolveAbilityDeletePolicy({
+      GRAVITY_FORMS_ALLOW_DELETE: 'false',
+      GRAVITYKIT_ALLOW_DELETE: 'true',
+    }),
+    true,
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -343,6 +385,50 @@ suite.test('catalog path: handlers execute via /wp-abilities/v1 run route with a
   TestAssert.isTrue(!!run, 'handler must hit the run endpoint');
   TestAssert.equal(run.url, '/wp-json/wp-abilities/v1/abilities/gk-gravitycharts/charts-list/run');
   TestAssert.equal(run.method, 'GET');
+});
+
+suite.test('catalog path: destructive abilities inherit the local delete gate', async () => {
+  const destructive = [{
+    name: 'gk-gravityview/view-delete',
+    description: 'Delete a View.',
+    input_schema: { type: 'object', properties: { id: { type: 'integer' } } },
+    annotations: { destructive: true, idempotent: true },
+    enabled: true,
+    mcp_tool_name: 'gv_view_delete',
+  }];
+  const blocked = buildCatalogStubGvClient([destructive]);
+  const blockedLoad = await loadAbilitiesAsTools(blocked, { allowDelete: false });
+  let blockedError;
+  try {
+    await blockedLoad.handlers.gv_view_delete({ id: 42 });
+  } catch (error) {
+    blockedError = error;
+  }
+  TestAssert.isTrue(!!blockedError, 'destructive ability must be rejected when delete is disabled');
+  TestAssert.isTrue(/GRAVITYKIT_ALLOW_DELETE=true/.test(blockedError.message), blockedError.message);
+  TestAssert.equal(
+    blocked.requests.filter((r) => typeof r.url === 'string' && r.url.includes('/run')).length,
+    0,
+    'blocked destructive abilities must not reach WordPress',
+  );
+
+  const allowed = buildCatalogStubGvClient([destructive]);
+  const allowedLoad = await loadAbilitiesAsTools(allowed, { allowDelete: true });
+  await allowedLoad.handlers.gv_view_delete({ id: 42 });
+  const run = allowed.requests.find((r) => typeof r.url === 'string' && r.url.includes('/run'));
+  TestAssert.equal(run.method, 'DELETE');
+});
+
+suite.test('catalog path: generated definitions include MCP annotations', async () => {
+  const stub = buildCatalogStubGvClient([syntheticFoundationCatalog()]);
+  const { definitions } = await loadAbilitiesAsTools(stub);
+  const listTool = definitions.find((d) => d.name === 'gv_views_list');
+  TestAssert.deepEqual(listTool.annotations, {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  });
 });
 
 suite.test('catalog path: paginates via X-WP-TotalPages', async () => {
@@ -634,7 +720,7 @@ suite.test('executeAbility: non-empty input on a schemaless ability still sends 
 
 suite.test('executeAbility: empty input → DELETE sends params {input:\'\'} (parity with GET)', async () => {
   const stub = buildCatalogStubGvClient([inputSchemaFenceCatalog()]);
-  const { handlers } = await loadAbilitiesAsTools(stub);
+  const { handlers } = await loadAbilitiesAsTools(stub, { allowDelete: true });
   await handlers.gv_schema_delete({});
   const run = findRun(stub, 'gk-gravityview/view-delete-hard');
   TestAssert.isTrue(!!run, 'DELETE ability must hit the run endpoint');

--- a/test/abilities-loader.test.js
+++ b/test/abilities-loader.test.js
@@ -157,11 +157,15 @@ suite.test('normalizeMcpAnnotations: preserves ability safety metadata for MCP c
   TestAssert.deepEqual(
     normalizeMcpAnnotations({ destructive: true, idempotent: false }),
     {
-      readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: false,
       openWorldHint: true,
     },
+  );
+  TestAssert.deepEqual(
+    normalizeMcpAnnotations({ readonly: null, destructive: null, idempotent: null }),
+    { openWorldHint: true },
+    'unknown WordPress annotations must stay unknown instead of being advertised as false',
   );
 });
 
@@ -425,8 +429,6 @@ suite.test('catalog path: generated definitions include MCP annotations', async 
   const listTool = definitions.find((d) => d.name === 'gv_views_list');
   TestAssert.deepEqual(listTool.annotations, {
     readOnlyHint: true,
-    destructiveHint: false,
-    idempotentHint: false,
     openWorldHint: true,
   });
 });

--- a/test/field-manager.test.js
+++ b/test/field-manager.test.js
@@ -6,6 +6,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { FieldManager } from '../src/field-operations/field-manager.js';
+import { fieldOperationTools } from '../src/field-operations/index.js';
 import { PositionEngine } from '../src/field-operations/field-positioner.js';
 import FieldAwareValidator from '../src/config/field-validation.js';
 
@@ -13,6 +14,7 @@ import FieldAwareValidator from '../src/config/field-validation.js';
 // actually consumes: getForm() resolves { form } and replaceForm() does a
 // direct PUT resolving { form } (see field-manager.js).
 const createMockApiClient = () => ({
+  allowDelete: true,
   getForm: async () => ({
     form: {
       id: 1,
@@ -370,6 +372,29 @@ test('FieldManager - updateField', async (t) => {
 });
 
 test('FieldManager - deleteField', async (t) => {
+  await t.test('advertises the same ALLOW_DELETE requirement as the other delete tools', () => {
+    const tool = fieldOperationTools.find((definition) => definition.name === 'gf_delete_field');
+    assert.match(tool.description, /ALLOW_DELETE=true/);
+  });
+
+  await t.test('requires the same ALLOW_DELETE gate as form, entry, and feed deletion', async () => {
+    const apiClient = createMockApiClient();
+    apiClient.allowDelete = false;
+    let saved = false;
+    apiClient.replaceForm = async (id, form) => { saved = true; return { form }; };
+    const manager = new FieldManager(apiClient, createMockRegistry(), createMockValidator());
+    manager.dependencyTracker = {
+      scanFormDependencies: () => ({ conditionalLogic: [] }),
+      hasBreakingDependencies: () => false
+    };
+
+    await assert.rejects(
+      () => manager.deleteField(1, 2),
+      /GRAVITY_FORMS_ALLOW_DELETE=true/
+    );
+    assert.strictEqual(saved, false, 'a blocked field deletion must not persist the form');
+  });
+
   await t.test('deletes field without dependencies', async () => {
     const apiClient = createMockApiClient();
     const registry = createMockRegistry();


### PR DESCRIPTION
## Summary

Align destructive-operation safety across the MCP server's two tool planes while preserving the autonomous, single-credential workflow:

- gate `gf_delete_field` with the same `GRAVITY_FORMS_ALLOW_DELETE` policy already used for form, entry, and feed deletion;
- gate destructive dynamic GravityKit abilities locally as well as through their WordPress `permission_callback`;
- propagate WordPress Ability safety annotations to MCP `ToolAnnotations`, so clients can correctly distinguish read-only, mutating, destructive, and idempotent tools;
- let dynamic destructive abilities inherit `GRAVITY_FORMS_ALLOW_DELETE`, with an optional `GRAVITYKIT_ALLOW_DELETE` override for deployments that need separate policy.

## Why

The previous behavior had two inconsistent paths:

1. `gf_delete_field` replaced the complete form without consulting `api.allowDelete`, even though every other static delete operation required the flag.
2. Dynamic tools discarded the Ability API's annotations and relied only on server-side permissions. MCP clients therefore could not classify those tools, and the local delete policy did not cover destructive dynamic abilities.

For autonomous operators, the clean model is one explicit full-authority switch plus rollback-first execution—not per-object credential swapping or misleadingly incomplete guardrails. For conservative deployments, deletes remain off by default and the product-specific override can be set independently.

## Compatibility

- No tool names, input schemas, routes, credential formats, or non-destructive behavior change.
- Existing deployments with `GRAVITY_FORMS_ALLOW_DELETE=true` retain delete access across both tool planes.
- `GRAVITYKIT_ALLOW_DELETE` is optional; when omitted it inherits the existing Gravity Forms flag.
- Destructive dynamic abilities are now blocked when both flags are false. This is the intended security hardening for the previously uncovered path.
- WordPress capability checks and Foundation per-ability enable/disable controls remain in force.

## Verification

- `npm run prepublishOnly` — passed
  - unit suites
  - Node test suite
  - field validation
  - GravityView tests
  - package lint
  - documentation freshness
- Added regression coverage for:
  - blocked field deletion performing no write;
  - field-delete tool description advertising the gate;
  - dynamic Ability annotation normalization;
  - environment-policy inheritance/override;
  - blocked destructive abilities never reaching WordPress;
  - explicitly allowed destructive abilities retaining the correct HTTP method.
- Packaged the branch and completed a real stdio MCP handshake through Hermes against a local WordPress/Gravity Forms mock: 27 tools discovered.

## Operational note

Snapshots, readback diffs, browser QC, and automatic rollback are orchestration concerns because the MCP server cannot infer the user's requested task boundary or guarantee restoration of every WordPress-side effect. This patch deliberately keeps that policy out of core while ensuring the server's local guardrails and MCP metadata are truthful and consistent.

cc @zackkatz — this is meant as a small, compatibility-oriented hardening patch rather than a broader privilege-model redesign. I would appreciate your view on whether the shared-flag inheritance is the right default for upstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable protection for destructive operations, including field deletion.
  * Added support for overriding deletion access through `GRAVITYKIT_ALLOW_DELETE`, with fallback to the existing Gravity Forms setting.
  * Improved tool metadata and documentation for deletion requirements.

* **Bug Fixes**
  * Prevented delete actions from executing or persisting changes when deletion is disabled.
  * Normalized tool annotations for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->